### PR TITLE
Consolidate imu_attitude and use only quaternions

### DIFF
--- a/demos/bolt_demo_sensor_reading.cpp
+++ b/demos/bolt_demo_sensor_reading.cpp
@@ -55,8 +55,6 @@ static THREAD_FUNCTION_RETURN_TYPE control_loop(void* args)
             print_vector("act slider pos                 ",
                          robot.get_slider_positions());
             print_vector("act imu quat                   ",
-                         robot.get_base_attitude_quaternion());
-            print_vector("act imu rpy                    ",
                          robot.get_base_attitude());
             print_vector("act imu acc                    ",
                          robot.get_base_accelerometer());

--- a/include/bolt/bolt.hpp
+++ b/include/bolt/bolt.hpp
@@ -183,7 +183,7 @@ public:
      * The method <acquire_sensors>"()" has to be called
      * prior to any getter to have up to date data.
      */
-    const Eigen::Ref<const Eigen::Vector3d> get_base_attitude()
+    const Eigen::Ref<const Eigen::Vector4d> get_base_attitude()
     {
         return base_attitude_;
     }
@@ -198,18 +198,6 @@ public:
     const Eigen::Ref<const Eigen::Vector3d> get_base_linear_acceleration()
     {
         return base_linear_acceleration_;
-    }
-
-    /**
-     * @brief get_base_accelerometer
-     * @return the base_accelerometer
-     * WARNING !!!!
-     * The method <acquire_sensors>"()" has to be called
-     * prior to any getter to have up to date data.
-     */
-    const Eigen::Ref<const Eigen::Vector4d> get_base_attitude_quaternion()
-    {
-        return base_attitude_quaternion_;
     }
 
     /**
@@ -358,13 +346,10 @@ private:
     Eigen::Vector3d base_gyroscope_;
 
     /** @brief base accelerometer. */
-    Eigen::Vector3d base_attitude_;
+    Eigen::Vector4d base_attitude_;
 
     /** @brief base accelerometer. */
     Eigen::Vector3d base_linear_acceleration_;
-
-    /** @brief base attitude quaternion. */
-    Eigen::Vector4d base_attitude_quaternion_;
 
     /** @brief Integers from the serial port.
      * - 4 sliders in [0, 1024]

--- a/src/bolt.cpp
+++ b/src/bolt.cpp
@@ -56,7 +56,6 @@ Bolt::Bolt()
     base_gyroscope_.setZero();
     base_attitude_.setZero();
     base_linear_acceleration_.setZero();
-    base_attitude_quaternion_.setZero();
 
     // Finite state machine for the control
     control_state_ = BoltControlState::initial;
@@ -111,8 +110,7 @@ void Bolt::acquire_sensors()
      */
     base_accelerometer_ = robot_->imu->GetAccelerometer();
     base_gyroscope_ = robot_->imu->GetGyroscope();
-    base_attitude_ = robot_->imu->GetAttitudeEuler();
-    base_attitude_quaternion_ = robot_->imu->GetAttitudeQuaternion();
+    base_attitude_ = robot_->imu->GetAttitudeQuaternion();
     base_linear_acceleration_ = robot_->imu->GetLinearAcceleration();
 
     // acquire the slider positions

--- a/src/dgm_bolt.cpp
+++ b/src/dgm_bolt.cpp
@@ -68,7 +68,6 @@ void DGMBolt::get_sensors_to_map(dynamic_graph_manager::VectorDGMap& map)
     map.at("base_gyroscope") = bolt_.get_base_gyroscope();
     map.at("base_attitude") = bolt_.get_base_attitude();
     map.at("base_linear_acceleration") = bolt_.get_base_linear_acceleration();
-    map.at("base_attitude_quaternion") = bolt_.get_base_attitude_quaternion();
     map.at("slider_positions") = bolt_.get_slider_positions();
 
     /**


### PR DESCRIPTION
To be merged with https://github.com/open-dynamic-robot-initiative/robot_properties_bolt/pull/6.