### PR TITLE
Some modifications to BoltHumanoid be on par with Solo12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,16 @@ find_package(PythonModules REQUIRED COMPONENTS robot_properties_bolt)
 # optional dependencies.
 find_package(dynamic_graph_manager QUIET)
 
-# Export de dependencies.
-ament_export_dependencies(odri_control_interface real_time_tools
-                          yaml_utils dynamic_graph_manager slider_box)
+# Export dependencies.
+ament_export_dependencies(
+  odri_control_interface
+  real_time_tools
+  yaml_utils
+  slider_box
+)
+if(${dynamic_graph_manager_FOUND})
+  ament_export_dependencies(dynamic_graph_manager)
+endif()
 
 # prepare the final export
 ament_export_interfaces(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)

--- a/include/bolt/bolt_humanoid.hpp
+++ b/include/bolt/bolt_humanoid.hpp
@@ -43,6 +43,9 @@ enum BoltControlState
 class BoltHumanoid
 {
 public:
+    //! @brief Set slider box port to this value to disable it.
+    inline static const std::string SLIDER_BOX_DISABLED = "none";
+
     /**
      * @brief Bolt is the constructor of the class.
      */
@@ -51,8 +54,15 @@ public:
     /**
      * @brief initialize the robot by setting aligning the motors and calibrate
      * the sensors to 0
+     *
+     * @param network_id Name of the network interface for connection to the
+     *      robot.
+     * @param slider_box_port Name of the serial port to which the slider box is
+     *      connected.  Set to "" or "none" if no slider box is used.  Set to
+     *      "auto" to auto-detect the port.
      */
-    void initialize(const std::string& network_id);
+    void initialize(const std::string& network_id,
+                    const std::string& slider_box_port = SLIDER_BOX_DISABLED);
 
     /**
      * @brief Sets the maximum motor currents.

--- a/include/bolt/bolt_humanoid.hpp
+++ b/include/bolt/bolt_humanoid.hpp
@@ -13,9 +13,9 @@
 
 #include <Eigen/Eigen>
 
-#include "slider_box/serial_reader.hpp"
 #include "odri_control_interface/calibration.hpp"
 #include "odri_control_interface/robot.hpp"
+#include "slider_box/serial_reader.hpp"
 
 namespace Eigen
 {
@@ -64,6 +64,34 @@ public:
      */
     void send_target_joint_torque(
         const Eigen::Ref<const Eigen::Vector9d> target_joint_torque);
+
+    /**
+     * @brief Sets the desired joint position of the P controller running on
+     * the card.
+     */
+    void send_target_joint_position(
+        const Eigen::Ref<Eigen::Vector9d> target_joint_position);
+
+    /**
+     * @brief Sets the desired joint velocity of the D controller running on
+     * the card.
+     */
+    void send_target_joint_velocity(
+        const Eigen::Ref<Eigen::Vector9d> target_joint_velocity);
+
+    /**
+     * @brief Sets the desired joint position gain P for the P controller
+     * running on the card.
+     */
+    void send_target_joint_position_gains(
+        const Eigen::Ref<Eigen::Vector9d> target_joint_position_gains);
+
+    /**
+     * @brief Sets the desired joint velocity gain D for the D controller
+     * running on the card.
+     */
+    void send_target_joint_velocity_gains(
+        const Eigen::Ref<Eigen::Vector9d> target_joint_velocity_gains);
 
     /**
      * @brief acquire_sensors acquire all available sensors, WARNING !!!!
@@ -241,7 +269,8 @@ public:
      * @return This gives the status (enabled/disabled of the onboard control
      * cards).
      */
-    const Eigen::Ref<const Eigen::Matrix<bool, BOLT_HUMANOID_NB_MOTOR_BOARD, 1> >
+    const Eigen::Ref<
+        const Eigen::Matrix<bool, BOLT_HUMANOID_NB_MOTOR_BOARD, 1> >
     get_motor_board_enabled()
     {
         return motor_board_enabled_;
@@ -299,7 +328,8 @@ public:
      */
     bool is_calibrating()
     {
-        return (control_state_ == BoltControlState::calibrate) || calibrate_request_;
+        return (control_state_ == BoltControlState::calibrate) ||
+               calibrate_request_;
     }
 
 private:

--- a/include/bolt/bolt_humanoid.hpp
+++ b/include/bolt/bolt_humanoid.hpp
@@ -55,6 +55,11 @@ public:
     void initialize(const std::string& network_id);
 
     /**
+     * @brief Sets the maximum motor currents.
+     */
+    void set_max_current(const double& max_current);
+
+    /**
      * @brief send_target_torques sends the target currents to the motors
      */
     void send_target_joint_torque(

--- a/include/bolt/bolt_humanoid.hpp
+++ b/include/bolt/bolt_humanoid.hpp
@@ -72,6 +72,11 @@ public:
     void wait_until_ready();
 
     /**
+     * @brief Check if the robot is ready.
+     */
+    bool is_ready();
+
+    /**
      * @brief Fill attitude quaternion.
      */
     void fill_base_attitude_quaternion();

--- a/src/bolt_humanoid.cpp
+++ b/src/bolt_humanoid.cpp
@@ -88,6 +88,11 @@ void BoltHumanoid::wait_until_ready()
     robot_->WaitUntilReady();
 }
 
+bool BoltHumanoid::is_ready()
+{
+    return robot_->IsReady();
+}
+
 void BoltHumanoid::acquire_sensors()
 {
     // Acquire the data.

--- a/src/bolt_humanoid.cpp
+++ b/src/bolt_humanoid.cpp
@@ -83,6 +83,11 @@ void BoltHumanoid::initialize(const std::string& network_id)
     robot_->Init();
 }
 
+void BoltHumanoid::set_max_current(const double& max_current)
+{
+    robot_->joints->SetMaximumCurrents(max_current);
+}
+
 void BoltHumanoid::wait_until_ready()
 {
     robot_->WaitUntilReady();

--- a/src/bolt_humanoid.cpp
+++ b/src/bolt_humanoid.cpp
@@ -49,7 +49,8 @@ BoltHumanoid::BoltHumanoid()
     // Slider bos infos.
     slider_positions_.setZero();
     active_estop_ = true;  // By default assume the estop is active.
-    slider_box_data_.resize(BOLT_HUMANOID_NB_SLIDER + 1, 0);  // 4 sliders + 1 e-stop.
+    slider_box_data_.resize(BOLT_HUMANOID_NB_SLIDER + 1,
+                            0);  // 4 sliders + 1 e-stop.
 
     // imu infos
     base_accelerometer_.setZero();
@@ -127,11 +128,11 @@ void BoltHumanoid::acquire_sensors()
     if (serial_reader_->fill_vector(slider_box_data_) > 10)
     {
         robot_->ReportError();
-        if(nb_time_we_acquired_sensors_ % 2000 == 0)
+        if (nb_time_we_acquired_sensors_ % 2000 == 0)
         {
             robot_->ReportError(
-            "The slider box is not responding correctly, "
-            "10 iteration are missing.");
+                "The slider box is not responding correctly, "
+                "10 iteration are missing.");
         }
     }
     for (unsigned i = 0; i < slider_positions_.size(); ++i)
@@ -162,7 +163,8 @@ void BoltHumanoid::acquire_sensors()
     //     robot_->ReportError();
     //     if(nb_time_we_acquired_sensors_ % 2000 == 0)
     //     {
-    //         robot_->ReportError("Base attitude not in the defined parameter.");
+    //         robot_->ReportError("Base attitude not in the defined
+    //         parameter.");
     //     }
     // }
     ++nb_time_we_acquired_sensors_;
@@ -211,6 +213,30 @@ void BoltHumanoid::send_target_joint_torque(
             robot_->SendCommand();
             break;
     }
+}
+
+void BoltHumanoid::send_target_joint_position(
+    const Eigen::Ref<Eigen::Vector9d> target_joint_position)
+{
+    robot_->joints->SetDesiredPositions(target_joint_position);
+}
+
+void BoltHumanoid::send_target_joint_velocity(
+    const Eigen::Ref<Eigen::Vector9d> target_joint_velocity)
+{
+    robot_->joints->SetDesiredVelocities(target_joint_velocity);
+}
+
+void BoltHumanoid::send_target_joint_position_gains(
+    const Eigen::Ref<Eigen::Vector9d> target_joint_position_gains)
+{
+    robot_->joints->SetPositionGains(target_joint_position_gains);
+}
+
+void BoltHumanoid::send_target_joint_velocity_gains(
+    const Eigen::Ref<Eigen::Vector9d> target_joint_velocity_gains)
+{
+    robot_->joints->SetVelocityGains(target_joint_velocity_gains);
 }
 
 void BoltHumanoid::request_calibration(


### PR DESCRIPTION
## Description

- Add some missing methods: `is_ready()`, `set_max_current()`, `send_target_joint_{position,velocity,gains}`
- Make dynamic_graph_manager really optional
- Make slider box optional.  **NOTE: this changes the default behaviour to not use the slider box.  Explicitly pass a serial port or "auto" to `initialize()` if you want to use it!**


## How I Tested

Used in conjunction with https://github.com/open-dynamic-robot-initiative/robot_interfaces_bolt


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [ ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
