### PR TITLE
fix: Robot is only really ready if state is ready

### DIFF
--- a/src/bolt_humanoid.cpp
+++ b/src/bolt_humanoid.cpp
@@ -108,7 +108,7 @@ void BoltHumanoid::wait_until_ready()
 
 bool BoltHumanoid::is_ready()
 {
-    return robot_->IsReady();
+    return control_state_ == BoltControlState::ready;
 }
 
 void BoltHumanoid::acquire_sensors()


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Previously, it was already reporting to be ready while homing was still ongoing.


## How I Tested
On the test bench

